### PR TITLE
Required fixes for SS4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Display simple one-time flash message with Twitter Bootstrap or Zurb Foundation 
 $ composer require axyr/silverstripe-flashmessage
 ```
 
+Add the template variable `$FlashMessage` to your Page template where you wish the flash dialog to appear.
+
 ## Usage
 The FlashMessage template has all the markup and attributes so that it will play nicely with the Twitter Bootstrap and Zurb Foundation frameworks.
 

--- a/client/javascript/flashmessage.js
+++ b/client/javascript/flashmessage.js
@@ -33,7 +33,7 @@
                 });
                 if (typeof modal == 'function') {
                     $('#FlashModal').modal('hide');
-                }else if (foundation == 'function') {
+                }else if (typeof foundation == 'function') {
                     $('#FlashModal').foundation('close');
                 }
             },2000);

--- a/src/Flash.php
+++ b/src/Flash.php
@@ -150,9 +150,9 @@ class Flash extends ViewableData implements TemplateGlobalProvider
     public function forTemplate()
     {
         if (self::config()->load_javascript) {
-             Requirements::javascript('vendor/axyr/silverstripe-flashmessage/client/javascript/flashmessage.js');
+             Requirements::javascript('axyr/silverstripe-flashmessage: client/javascript/flashmessage.js');
         }
-        return $this->customise($this->data)->renderWith(self::config()->template);
+        return $this->renderWith(self::config()->template, $this->data);
     }
 
     /**


### PR DESCRIPTION
There are a few issues with the SS4 version of the module:

- Template rendering wasn't functional; data weren't correctly merged into the `ViewableData`
- Javascript error when checking for foundation; missing `typeof`
- No mention of inserting the template variable - `$FlashMessage` - into the Page template to facilitate rendering

This commit fixes these issues.  Please merge and make a new tag for SS4 (so that Composer will install it correctly into an SS4 project).

Thank you!